### PR TITLE
Fix loadFile for edge case machines

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,8 +1,8 @@
 'use strict';
 const path = require('path');
+const url = require('url');
 const electron = require('electron');
 const isDev = require('electron-is-dev');
-const url = require('url');
 const node = require('./node');
 
 // TODO: Implement everything

--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@
 const path = require('path');
 const electron = require('electron');
 const isDev = require('electron-is-dev');
+const url = require('url');
 const node = require('./node');
 
 // TODO: Implement everything
@@ -60,7 +61,11 @@ const activeWindow = () => is.main ?
 
 exports.activeWindow = activeWindow;
 
-exports.loadFile = (win, filePath) => win.loadURL(`file://${path.resolve(electron.app.getAppPath(), filePath)}`);
+exports.loadFile = (win, filePath) => win.loadURL(url.format({
+	protocol: 'file',
+	slashes: true,
+	pathname: path.resolve(electron.app.getAppPath(), filePath)
+}));
 
 exports.runJS = (code, win = activeWindow()) => win.webContents.executeJavaScript(code);
 


### PR DESCRIPTION
On some machines just loading the current path as a string won't work, for instance, there are some users on Windows who have a "#" inside there username.  This will cause loading the path directly to break, as everything after the # will be treated as an anchor.  The solution is to use `url.format` which will escape URL components appropriately.

Disclaimer:  Made this change on GitHub's online file editor 😄 