### PR TITLE
Make .loadFile() backwards compatible

### DIFF
--- a/index.js
+++ b/index.js
@@ -49,11 +49,7 @@ const activeWindow = () => is.main ?
 
 exports.activeWindow = activeWindow;
 
-exports.loadFile = (win, filePath) => win.loadURL(url.format({
-	protocol: 'file',
-	slashes: true,
-	pathname: path.resolve(electron.app.getAppPath(), filePath)
-}));
+exports.loadFile = (win, filePath, options = {}) => win.loadFile(filePath, options);
 
 exports.runJS = (code, win = activeWindow()) => win.webContents.executeJavaScript(code);
 

--- a/readme.md
+++ b/readme.md
@@ -92,18 +92,6 @@ Type: `Function`
 
 Returns the active window.
 
-### loadFile(window, filePath)
-
-Load a file into the given window using a file path relative to the root of the app.
-
-```js
-loadFile(win, 'index.html');
-```
-
-You use this instead of the verbose ```win.loadURL(`file://…`);```
-
-[Read more.](https://github.com/electron/electron/issues/11560)
-
 ### runJS(code, [window])
 
 Type: `Function`


### PR DESCRIPTION
This commit points the obsolete `.loadFile()` to Electron's [`BrowserWindow.loadFile()`](https://electronjs.org/docs/api/browser-window#winloadfilefilepath) in order to make it backwards compatible with old code using electron-util.