### PR TITLE
Remove `.loadFile()` in favor of Electron's `BrowserWindow#loadFile()`

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,5 @@
 'use strict';
 const path = require('path');
-const url = require('url');
 const electron = require('electron');
 const isDev = require('electron-is-dev');
 const node = require('./node');
@@ -48,12 +47,6 @@ const activeWindow = () => is.main ?
 	electron.remote.getCurrentWindow();
 
 exports.activeWindow = activeWindow;
-
-exports.loadFile = (win, filePath) => win.loadURL(url.format({
-	protocol: 'file',
-	slashes: true,
-	pathname: path.resolve(electron.app.getAppPath(), filePath)
-}));
 
 exports.runJS = (code, win = activeWindow()) => win.webContents.executeJavaScript(code);
 

--- a/readme.md
+++ b/readme.md
@@ -92,18 +92,6 @@ Type: `Function`
 
 Returns the active window.
 
-### loadFile(window, filePath)
-
-Load a file into the given window using a file path relative to the root of the app.
-
-```js
-loadFile(win, 'index.html');
-```
-
-You use this instead of the verbose ```win.loadURL(`file://…`);```
-
-[Read more.](https://github.com/electron/electron/issues/11560)
-
 ### runJS(code, [window])
 
 Type: `Function`


### PR DESCRIPTION
Removes the function as discussed in PR https://github.com/sindresorhus/electron-util/pull/9