### PR TITLE
Remove now-native setWindowBounds functionality

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -212,30 +212,6 @@ export interface OptionalRectangle {
 	readonly y?: number;
 }
 
-export interface SetWindowBoundsOptions {
-	/**
-	The window to set the bounds of.
-
-	Default: Current window
-	*/
-	readonly window?: BrowserWindow;
-
-	/**
-	Animate the change.
-
-	@default false
-	*/
-	readonly animated?: boolean;
-}
-
-/**
-Set the bounds of a window. This is similar to the [`BrowserWindow#setBounds()`](https://electronjs.org/docs/api/browser-window#winsetboundsbounds-animate) method, but it allows setting any of the `x`, `y`, `width`, `height` properties, instead of forcing you to set them all at once.
-The properties that are not set will just fall back to the current ones.
-
-@param bounds - New window bounds.
-*/
-export function setWindowBounds(bounds: OptionalRectangle, options?: SetWindowBoundsOptions): void;
-
 export interface CenterWindowOptions {
 	/**
 	The window to center.

--- a/index.js
+++ b/index.js
@@ -102,16 +102,6 @@ exports.getWindowBoundsCentered = options => {
 	};
 };
 
-exports.setWindowBounds = (bounds, options) => {
-	options = {
-		window: activeWindow(),
-		animated: false,
-		...options
-	};
-
-	options.window.setBounds(bounds, options.animated);
-};
-
 exports.centerWindow = options => {
 	options = {
 		window: activeWindow(),

--- a/index.js
+++ b/index.js
@@ -110,7 +110,7 @@ exports.centerWindow = options => {
 	};
 
 	const bounds = exports.getWindowBoundsCentered(options);
-	exports.setWindowBounds(bounds, options);
+	options.window.setBounds(bounds, options.animated);
 };
 
 exports.disableZoom = (win = activeWindow()) => {

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -12,7 +12,6 @@ import {
 	enforceMacOSAppLocation,
 	menuBarHeight,
 	getWindowBoundsCentered,
-	setWindowBounds,
 	centerWindow,
 	disableZoom,
 	appLaunchTimestamp,
@@ -47,7 +46,6 @@ expectType<string>(fixPathForAsarUnpack('/path'));
 expectType<void>(enforceMacOSAppLocation());
 expectType<number>(menuBarHeight());
 expectType<Rectangle>(getWindowBoundsCentered());
-expectType<void>(setWindowBounds({width: 1920, height: 1080}));
 expectType<void>(centerWindow({}));
 expectType<void>(disableZoom());
 expectType<number>(appLaunchTimestamp);

--- a/readme.md
+++ b/readme.md
@@ -39,7 +39,6 @@ console.log(is.macos && is.main);
 - [`enforceMacOSAppLocation()`](#enforcemacosapplocation-macos)
 - [`menuBarHeight()`](#menubarheight-macos)
 - [`getWindowBoundsCentered()`](#getwindowboundscenteredoptions)
-- [`setWindowBounds()`](#setwindowboundsbounds-options)
 - [`centerWindow()`](#centerwindowoptions)
 - [`disableZoom()`](#disablezoomwindow)
 - [`appLaunchTimestamp`](#applaunchtimestamp)
@@ -185,10 +184,6 @@ Type: `object`<br>
 Default: Size of `window`
 
 Set a new window size. Example: `{width: 600, height: 400}`
-
-### setWindowBounds(bounds, [options])
-
-Set the bounds of a window. This is similar to the [`BrowserWindow#setBounds()`](https://electronjs.org/docs/api/browser-window#winsetboundsbounds-animate) method, but it allows setting any of the `x`, `y`, `width`, `height` properties, instead of forcing you to set them all at once. The properties that are not set will just fall back to the current ones.
 
 #### options
 


### PR DESCRIPTION
This PR removes the `setWindowBounds` utility function, as it's natively available in Electron starting with `v4.0.0` as a result of [this PR](https://github.com/electron/electron/pull/15677).