### PR TITLE
Use native Linux implementation in `.showAboutWindow()`

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -431,7 +431,7 @@ export interface ShowAboutWindowOptions {
 }
 
 /**
-Shows an 'About' window. On macOS, the native 'About' window is shown, and on Linux and Windows, a simple custom dialog is shown.
+Shows an 'About' window. On macOS and Linux, the native 'About' window is shown, and on Windows, a simple custom dialog is shown.
 On macOS, the `icon`, `text`, and `title` options are ignored.
 
 _It will show `Electron` as the app name until you build your app for production._

--- a/index.js
+++ b/index.js
@@ -237,7 +237,7 @@ exports.openUrlMenuItem = (options = {}) => {
 };
 
 exports.showAboutWindow = options => {
-	if (is.macos) {
+	if (!is.windows) {
 		if (options.copyright) {
 			api.app.setAboutPanelOptions({copyright: options.copyright});
 		}

--- a/readme.md
+++ b/readme.md
@@ -372,7 +372,7 @@ Menu.setApplicationMenu(menu);
 
 ### showAboutWindow(options)
 
-Shows an 'About' window. On macOS, the native 'About' window is shown, and on Linux and Windows, a simple custom dialog is shown.
+Shows an 'About' window. On macOS and Linux, the native 'About' window is shown, and on Windows, a simple custom dialog is shown.
 
 On macOS, the `icon`, `text`, and `title` options are ignored.
 


### PR DESCRIPTION
Updates `showAboutWindow` to use native about panel on Linux, which was made available in Electron via [this PR](https://github.com/electron/electron/pull/15658) starting in Electron `v5.0.0`.