### PR TITLE
`enforceMacOSAppLocation`: showing an error when another version of the app is already running

### DIFF
--- a/source/enforce-macos-app-location.js
+++ b/source/enforce-macos-app-location.js
@@ -30,5 +30,17 @@ module.exports = () => {
 		return;
 	}
 
-	api.app.moveToApplicationsFolder();
+	api.app.moveToApplicationsFolder({
+    conflictHandler: conflict => {
+      if (conflict === 'existsAndRunning') { // Can't replace the active version of the app
+        api.dialog.showMessageBoxSync({
+          type: 'error',
+          message: `Another version of ${appName} is currently running, quit it and retry.`,
+          buttons: [`Quit ${appName}`]
+        });
+        app.quit();
+      }
+      return true;
+    }
+	});
 };

--- a/source/enforce-macos-app-location.js
+++ b/source/enforce-macos-app-location.js
@@ -35,7 +35,7 @@ module.exports = () => {
 			if (conflict === 'existsAndRunning') { // Can't replace the active version of the app
 				api.dialog.showMessageBoxSync({
 					type: 'error',
-					message: `Another version of ${app.getName()} is currently running. Quit it, then launch this version of the app again.`,
+					message: `Another version of ${api.app.getName()} is currently running. Quit it, then launch this version of the app again.`,
 					buttons: [
 						'OK'
 					]

--- a/source/enforce-macos-app-location.js
+++ b/source/enforce-macos-app-location.js
@@ -31,16 +31,17 @@ module.exports = () => {
 	}
 
 	api.app.moveToApplicationsFolder({
-    conflictHandler: conflict => {
-      if (conflict === 'existsAndRunning') { // Can't replace the active version of the app
-        api.dialog.showMessageBoxSync({
-          type: 'error',
-          message: `Another version of ${appName} is currently running, quit it and retry.`,
-          buttons: [`Quit ${appName}`]
-        });
-        app.quit();
-      }
-      return true;
-    }
+		conflictHandler: conflict => {
+			if (conflict === 'existsAndRunning') { // Can't replace the active version of the app
+				api.dialog.showMessageBoxSync({
+					type: 'error',
+					message: `Another version of ${appName} is currently running, quit it and retry.`,
+					buttons: [`Quit ${appName}`]
+				});
+				api.app.quit();
+			}
+
+			return true;
+		}
 	});
 };

--- a/source/enforce-macos-app-location.js
+++ b/source/enforce-macos-app-location.js
@@ -35,9 +35,12 @@ module.exports = () => {
 			if (conflict === 'existsAndRunning') { // Can't replace the active version of the app
 				api.dialog.showMessageBoxSync({
 					type: 'error',
-					message: `Another version of ${app.getName ()} is currently running. Quit it, then launch this version of the app again.`,
-					buttons: ['OK']
+					message: `Another version of ${app.getName()} is currently running. Quit it, then launch this version of the app again.`,
+					buttons: [
+						'OK'
+					]
 				});
+
 				api.app.quit();
 			}
 

--- a/source/enforce-macos-app-location.js
+++ b/source/enforce-macos-app-location.js
@@ -35,8 +35,8 @@ module.exports = () => {
 			if (conflict === 'existsAndRunning') { // Can't replace the active version of the app
 				api.dialog.showMessageBoxSync({
 					type: 'error',
-					message: `Another version of ${appName} is currently running, quit it and retry.`,
-					buttons: [`Quit ${appName}`]
+					message: `Another version of ${app.getName ()} is currently running. Quit it, then launch this version of the app again.`,
+					buttons: ['OK']
 				});
 				api.app.quit();
 			}


### PR DESCRIPTION
Closes #13.

The linter isn't working properly as it's throwing an error coming from a file inside `node_modules`, so there are probably some errors in this PR according to your linter.