### PR TITLE
Fix `enforceMacOSAppLocation` crash

### DIFF
--- a/source/enforce-macos-app-location.js
+++ b/source/enforce-macos-app-location.js
@@ -23,7 +23,7 @@ module.exports = () => {
 		],
 		defaultId: 0,
 		cancelId: 1
-	}).response;
+	});
 
 	if (clickedButtonIndex === 1) {
 		api.app.quit();

--- a/source/enforce-macos-app-location.js
+++ b/source/enforce-macos-app-location.js
@@ -13,7 +13,7 @@ module.exports = () => {
 
 	const appName = 'name' in api.app ? api.app.name : api.app.getName();
 
-	const clickedButtonIndex = api.dialog.showMessageBoxSync({
+	const {response: clickedButtonIndex} = api.dialog.showMessageBoxSync({
 		type: 'error',
 		message: 'Move to Applications folder?',
 		detail: `${appName} must live in the Applications folder to be able to run correctly.`,

--- a/source/enforce-macos-app-location.js
+++ b/source/enforce-macos-app-location.js
@@ -13,7 +13,7 @@ module.exports = () => {
 
 	const appName = 'name' in api.app ? api.app.name : api.app.getName();
 
-	const {response: clickedButtonIndex} = api.dialog.showMessageBoxSync({
+	const clickedButtonIndex = api.dialog.showMessageBoxSync({
 		type: 'error',
 		message: 'Move to Applications folder?',
 		detail: `${appName} must live in the Applications folder to be able to run correctly.`,

--- a/source/enforce-macos-app-location.js
+++ b/source/enforce-macos-app-location.js
@@ -23,7 +23,7 @@ module.exports = () => {
 		],
 		defaultId: 0,
 		cancelId: 1
-	});
+	}).response;
 
 	if (clickedButtonIndex === 1) {
 		api.app.quit();

--- a/source/enforce-macos-app-location.js
+++ b/source/enforce-macos-app-location.js
@@ -13,7 +13,7 @@ module.exports = () => {
 
 	const appName = 'name' in api.app ? api.app.name : api.app.getName();
 
-	const clickedButtonIndex = api.dialog.showMessageBox({
+	const clickedButtonIndex = api.dialog.showMessageBoxSync({
 		type: 'error',
 		message: 'Move to Applications folder?',
 		detail: `${appName} must live in the Applications folder to be able to run correctly.`,


### PR DESCRIPTION
`showMessageBox` returns a promise so it always moved the app to the Applications folder regardless of user selection. In certain cases this crashed the app.