### PR TITLE
Replace built in `remote` module with `@electron/remote`

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,7 +1,7 @@
 /// <reference lib="dom"/>
 /// <reference types="electron"/>
 /// <reference types="node"/>
-import {AllElectron, Remote, BrowserWindow, Size, Rectangle, Session, MenuItemConstructorOptions, MenuItem} from 'electron';
+import {RemoteMainInterface, BrowserWindow, Size, Rectangle, Session, MenuItemConstructorOptions, MenuItem} from 'electron';
 import {Options as NewGithubIssueUrlOptions} from 'new-github-issue-url';
 import {RequireAtLeastOne} from 'type-fest';
 
@@ -14,7 +14,13 @@ Access the Electron APIs in both the main and renderer process without having to
 api.app.quit(); // The `app` API is usually only available in the main process.
 ```
 */
-export const api: AllElectron | Remote;
+export const api: RemoteMainInterface;
+
+/**
+Initialize the [`remote`](https://github.com/electron/remote) module to be able to use `api` and other functionalities in the render process.
+This must be called from the main process and requires to set the `enableRemoteModule` to `true` in the webPreferences of the BrowserWindow.
+*/
+export function initializeRemote(): void;
 
 /**
 Check for various things.

--- a/index.js
+++ b/index.js
@@ -5,9 +5,10 @@ const electron = require('electron');
 const newGithubIssueUrl = require('new-github-issue-url');
 const node = require('./node');
 
-const api = require('./source/api');
+const {api, remote, initializeRemote} = require('./source/api');
 
 exports.api = api;
+exports.initializeRemote = initializeRemote;
 
 const is = require('./source/is');
 
@@ -33,7 +34,7 @@ exports.platform = object => {
 
 const activeWindow = () => is.main ?
 	electron.BrowserWindow.getFocusedWindow() :
-	electron.remote.getCurrentWindow();
+	remote.getCurrentWindow();
 
 exports.activeWindow = activeWindow;
 

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -1,7 +1,8 @@
-import {AllElectron, Remote, BrowserWindow, Rectangle, MenuItemConstructorOptions} from 'electron';
+import {RemoteMainInterface, BrowserWindow, Rectangle, MenuItemConstructorOptions} from 'electron';
 import {expectType, expectError} from 'tsd';
 import {
 	api,
+	initializeRemote,
 	is,
 	electronVersion,
 	chromeVersion,
@@ -27,7 +28,8 @@ import {
 	openSystemPreferences
 } from '.';
 
-expectType<AllElectron | Remote>(api);
+expectType<RemoteMainInterface>(api);
+expectType<void>(initializeRemote());
 expectType<boolean>(api.app.isPackaged);
 expectType<boolean>(is.macos);
 expectType<string>(electronVersion);

--- a/package.json
+++ b/package.json
@@ -33,12 +33,13 @@
 		"useful"
 	],
 	"dependencies": {
+		"@electron/remote": "^1.0.2",
 		"electron-is-dev": "^1.1.0",
 		"new-github-issue-url": "^0.2.1"
 	},
 	"devDependencies": {
 		"ava": "^2.1.0",
-		"electron": "^8.0.1",
+		"electron": "^10.2.0",
 		"mock-require": "^3.0.3",
 		"tsd": "^0.11.0",
 		"type-fest": "^0.10.0",

--- a/source/api.js
+++ b/source/api.js
@@ -1,6 +1,31 @@
 'use strict';
-const electron = require('electron');
 
-module.exports = new Proxy(electron, {
-	get: (target, property) => target[property] || (target.remote ? target.remote[property] : undefined)
+const electron = require('electron');
+const {initialize} = require('@electron/remote/main');
+
+const initializeRemote = () => {
+	if (process.type !== 'browser') {
+		throw new Error('The remote api must be initialized from the main process.');
+	}
+
+	initialize();
+};
+
+const remote = new Proxy({}, {
+	get: (target, property) => {
+		const remote = require('@electron/remote');
+		return remote[property];
+	}
 });
+
+const api = new Proxy(electron, {
+	get: (target, property) => {
+		if (target[property]) {
+			return target[property];
+		}
+
+		return remote[property];
+	}
+});
+
+module.exports = {initializeRemote, remote, api};


### PR DESCRIPTION
Started working on #36 and got something working, but not sure how much I like the code, so I thought I open a draft PR for now.

My main concern was that using `@electron/remote` is somewhat discouraged by the _(electron)_ developers.
I only ever used `electron-util` from the main process, so it is hard for me to know what functionality is useful in the render process.
But I get that it is convenient to be able to use it in both processes without thinking about it.

Some alternative ideas I had:

1.	Have `@electron/remote` as a peer dependency so that `electron-util` doesn't need to worry about the initialization.

2.	Split the module into a `electron-util/main` and `electron-util/renderer` then each can be required as needed.
	The main bundle could also expose the right module conditionally, this is already done for `isFirstAppLaunch`.
	Then the user could decide if they want to use the `remote` module to e.g. `remote.require('electron-util/main')`.

Happy for any other suggestions, about this because I only know my use cases :sweat_smile:


**To-Do for this PR:**
- [ ] Require `electron@>=10` _(How? Just in the `readme`?)_
- [ ] Update `readme` and explain the `remote` initialization

---

Fixes #36