### PR TITLE
Add `useFullBounds` option for `getWindowBoundsCentered()` and `centerWindow()`

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -185,7 +185,7 @@ export interface GetWindowBoundsCenteredOptions {
 	/**
 	Use the full display size when calculating the position, rather than just the workable area.
 
-	Default: `false`
+	@default false
 	```
 	*/
 	readonly useFullBounds?: boolean;

--- a/index.d.ts
+++ b/index.d.ts
@@ -183,10 +183,10 @@ export interface GetWindowBoundsCenteredOptions {
 	readonly size?: Size;
 
 	/**
-	Use the full display size when calculating the position, rather than just the workable area.
+	Use the full display size when calculating the position.
+	By default, only the workable screen area is used, which excludes the Windows taskbar and macOS dock.
 
 	@default false
-	```
 	*/
 	readonly useFullBounds?: boolean;
 }
@@ -248,10 +248,10 @@ export interface CenterWindowOptions {
 	readonly animated?: boolean;
 
 	/**
-	Use the full display size when calculating the position, rather than just the workable area.
+	Use the full display size when calculating the position.
+	By default, only the workable screen area is used, which excludes the Windows taskbar and macOS dock.
 
-	Default: `false`
-	```
+	@default false
 	*/
 	readonly useFullBounds?: boolean;
 }

--- a/index.d.ts
+++ b/index.d.ts
@@ -181,6 +181,14 @@ export interface GetWindowBoundsCenteredOptions {
 	```
 	*/
 	readonly size?: Size;
+
+	/**
+	Use the full display size when calculating the position, rather than just the workable area.
+
+	Default: `false`
+	```
+	*/
+	readonly useFullBounds?: boolean;
 }
 
 /**
@@ -238,6 +246,14 @@ export interface CenterWindowOptions {
 	@default false
 	*/
 	readonly animated?: boolean;
+
+	/**
+	Use the full display size when calculating the position, rather than just the workable area.
+
+	Default: `false`
+	```
+	*/
+	readonly useFullBounds?: boolean;
 }
 
 /**

--- a/index.js
+++ b/index.js
@@ -53,7 +53,7 @@ exports.getWindowBoundsCentered = options => {
 
 	const [width, height] = options.window.getSize();
 	const windowSize = options.size || {width, height};
-	const screenSize = includeFullDisplayBounds ?
+	const screenSize = options.includeFullDisplayBounds ?
 		api.screen.getDisplayNearestPoint(api.screen.getCursorScreenPoint()).bounds :
 		api.screen.getDisplayNearestPoint(api.screen.getCursorScreenPoint()).workArea;
 	const x = Math.floor(screenSize.x + ((screenSize.width / 2) - (windowSize.width / 2)));

--- a/index.js
+++ b/index.js
@@ -51,7 +51,7 @@ exports.getWindowBoundsCentered = options => {
 		...options
 	};
 
-	const currentDisplay = api.screen.getDisplayNearestPoint(api.screen.getCursorScreenPoint())
+	const currentDisplay = api.screen.getDisplayNearestPoint(api.screen.getCursorScreenPoint());
 	const [width, height] = options.window.getSize();
 	const windowSize = options.size || {width, height};
 	const screenSize = options.useFullBounds ?

--- a/index.js
+++ b/index.js
@@ -51,11 +51,12 @@ exports.getWindowBoundsCentered = options => {
 		...options
 	};
 
+	const currentDisplay = api.screen.getDisplayNearestPoint(api.screen.getCursorScreenPoint())
 	const [width, height] = options.window.getSize();
 	const windowSize = options.size || {width, height};
-	const screenSize = options.includeFullDisplayBounds ?
-		api.screen.getDisplayNearestPoint(api.screen.getCursorScreenPoint()).bounds :
-		api.screen.getDisplayNearestPoint(api.screen.getCursorScreenPoint()).workArea;
+	const screenSize = options.useFullBounds ?
+		currentDisplay.bounds :
+		currentDisplay.workArea;
 	const x = Math.floor(screenSize.x + ((screenSize.width / 2) - (windowSize.width / 2)));
 	const y = Math.floor(((screenSize.height + screenSize.y) / 2) - (windowSize.height / 2));
 

--- a/index.js
+++ b/index.js
@@ -53,7 +53,9 @@ exports.getWindowBoundsCentered = options => {
 
 	const [width, height] = options.window.getSize();
 	const windowSize = options.size || {width, height};
-	const screenSize = api.screen.getDisplayNearestPoint(api.screen.getCursorScreenPoint()).workArea;
+	const screenSize = includeFullDisplayBounds ?
+		api.screen.getDisplayNearestPoint(api.screen.getCursorScreenPoint()).bounds :
+		api.screen.getDisplayNearestPoint(api.screen.getCursorScreenPoint()).workArea;
 	const x = Math.floor(screenSize.x + ((screenSize.width / 2) - (windowSize.width / 2)));
 	const y = Math.floor(((screenSize.height + screenSize.y) / 2) - (windowSize.height / 2));
 

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -47,7 +47,7 @@ expectType<string>(fixPathForAsarUnpack('/path'));
 expectType<void>(enforceMacOSAppLocation());
 expectType<number>(menuBarHeight());
 expectType<Rectangle>(getWindowBoundsCentered());
-expectType<Rectangle>(getWindowBoundsCentered({ useFullBounds: true }));
+expectType<Rectangle>(getWindowBoundsCentered({useFullBounds: true}));
 expectType<void>(centerWindow({}));
 expectType<void>(disableZoom());
 expectType<number>(appLaunchTimestamp);

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -47,7 +47,7 @@ expectType<string>(fixPathForAsarUnpack('/path'));
 expectType<void>(enforceMacOSAppLocation());
 expectType<number>(menuBarHeight());
 expectType<Rectangle>(getWindowBoundsCentered());
-expectType<Rectangle>(getWindowBoundsCentered({ includeFullDisplayBounds: true }));
+expectType<Rectangle>(getWindowBoundsCentered({ useFullBounds: true }));
 expectType<void>(centerWindow({}));
 expectType<void>(disableZoom());
 expectType<number>(appLaunchTimestamp);

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -47,6 +47,7 @@ expectType<string>(fixPathForAsarUnpack('/path'));
 expectType<void>(enforceMacOSAppLocation());
 expectType<number>(menuBarHeight());
 expectType<Rectangle>(getWindowBoundsCentered());
+expectType<Rectangle>(getWindowBoundsCentered({ includeFullDisplayBounds: true }));
 expectType<void>(centerWindow({}));
 expectType<void>(disableZoom());
 expectType<number>(appLaunchTimestamp);

--- a/readme.md
+++ b/readme.md
@@ -223,7 +223,7 @@ Animate the change.
 Type: `boolean`\
 Default: `false`
 
-Use the full display size when calculating the position. By default only the workable screen area is used, which excludes the Windows taskbar and MacOS dock.
+Use the full display size when calculating the position. By default, only the workable screen area is used, which excludes the Windows taskbar and macOS dock.
 
 ### disableZoom([window])
 

--- a/readme.md
+++ b/readme.md
@@ -182,23 +182,12 @@ Default: Size of `window`
 
 Set a new window size. Example: `{width: 600, height: 400}`
 
-#### options
-
-Type: `object`
-
-##### window
-
-Type: [`BrowserWindow`](https://electronjs.org/docs/api/browser-window)\
-Default: Current window
-
-The window to set the bounds of.
-
-##### animated
+##### includeFullDisplayBounds
 
 Type: `boolean`\
 Default: `false`
 
-Animate the change.
+Use the full display size when calculating the position. By default only the workable screen area is used, which excludes the Windows taskbar and MacOS dock.
 
 ### centerWindow(options?)
 
@@ -228,6 +217,13 @@ Type: `boolean`\
 Default: `false`
 
 Animate the change.
+
+##### includeFullDisplayBounds
+
+Type: `boolean`\
+Default: `false`
+
+Use the full display size when calculating the position. By default only the workable screen area is used, which excludes the Windows taskbar and MacOS dock.
 
 ### disableZoom([window])
 

--- a/readme.md
+++ b/readme.md
@@ -182,7 +182,7 @@ Default: Size of `window`
 
 Set a new window size. Example: `{width: 600, height: 400}`
 
-##### includeFullDisplayBounds
+##### useFullBounds
 
 Type: `boolean`\
 Default: `false`
@@ -218,7 +218,7 @@ Default: `false`
 
 Animate the change.
 
-##### includeFullDisplayBounds
+##### useFullBounds
 
 Type: `boolean`\
 Default: `false`


### PR DESCRIPTION
This allows for centered windows to ignore the space taken by the Windows taskbar or the MacOS dock so that programs can accurately be centered.

Fixes #41 