### PR TITLE
Show about window on active window

### DIFF
--- a/index.js
+++ b/index.js
@@ -228,17 +228,20 @@ exports.showAboutWindow = (options = {}) => {
 
 	const text = options.text ? `${options.copyright ? '\n\n' : ''}${options.text}` : '';
 
-	api.dialog.showMessageBox({
-		title: `${options.title} ${appName}`,
-		message: `Version ${api.app.getVersion()}`,
-		detail: (options.copyright || '') + text,
-		icon: options.icon,
+	api.dialog.showMessageBox(
+		activeWindow(),
+		{
+			title: `${options.title} ${appName}`,
+			message: `Version ${api.app.getVersion()}`,
+			detail: (options.copyright || '') + text,
+			icon: options.icon,
 
-		// This is needed for Linux, since at least Ubuntu does not show a close button
-		buttons: [
-			'OK'
-		]
-	});
+			// This is needed for Linux, since at least Ubuntu does not show a close button
+			buttons: [
+				'OK'
+			]
+		}
+	);
 };
 
 exports.aboutMenuItem = (options = {}) => {


### PR DESCRIPTION
This change passes the active window for the message box. If an application has "Always On Top" set, this will still show the message box on top of the active window. Without passing a window, it might display behind a current window.

I believe this should fix https://github.com/sindresorhus/caprine/issues/1517.