### PR TITLE
Add support for Windows for `.openSystemPreferences()` API

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -582,8 +582,8 @@ export interface SystemPreferencesMacOsPanes {
 
 export type SystemPreferencesWindowsPane =
 	/**
-	 * System
-	 */
+	System
+	*/
 	'display'
 	| 'sound' // Build 17063+
 	| 'notifications'
@@ -599,8 +599,8 @@ export type SystemPreferencesWindowsPane =
 	| 'remotedesktop'
 	| 'about'
 	/**
-	 * Devices
-	 */
+	Devices
+	*/
 	| 'bluetooth'
 	| 'connecteddevices'
 	| 'printers'
@@ -613,8 +613,8 @@ export type SystemPreferencesWindowsPane =
 	| 'usb'
 	| 'mobile-devices' // Build 16251+
 	/**
-	 * Network & Internet
-	 */
+	Network & Internet
+	*/
 	| 'network'
 	| 'network-status'
 	| 'network-cellular'
@@ -629,8 +629,8 @@ export type SystemPreferencesWindowsPane =
 	| 'datausage'
 	| 'network-proxy'
 	/**
-	 * Personalization
-	 */
+	Personalization
+	*/
 	| 'personalization'
 	| 'personalization-background'
 	| 'personalization-colors'
@@ -640,8 +640,8 @@ export type SystemPreferencesWindowsPane =
 	| 'personalization-start'
 	| 'taskbar'
 	/**
-	 * Apps
-	 */
+	Apps
+	*/
 	| 'appsfeatures'
 	| 'optionalfeatures'
 	| 'defaultapps'
@@ -650,8 +650,8 @@ export type SystemPreferencesWindowsPane =
 	| 'videoplayback' // Build 16215+
 	| 'startupapps' // Build 17017+
 	/**
-	 * Accounts
-	 */
+	Accounts
+	*/
 	| 'yourinfo'
 	| 'emailandaccounts'
 	| 'signinoptions'
@@ -659,23 +659,23 @@ export type SystemPreferencesWindowsPane =
 	| 'otherusers'
 	| 'sync'
 	/**
-	 * Time & language
-	 */
+	Time & language
+	*/
 	| 'dateandtime'
 	| 'regionformatting'
 	| 'regionlanguage'
 	| 'speech'
 	/**
-	 * Gaming
-	 */
+	Gaming
+	*/
 	| 'gaming-gamebar'
 	| 'gaming-gamedvr'
 	| 'gaming-broadcasting'
 	| 'gaming-gamemode'
 	| 'gaming-xboxnetworking' // Build 16226+
 	/**
-	 * Ease of Access
-	 */
+	Ease of Access
+	*/
 	| 'easeofaccess-display' // Build 17025+
 	| 'easeofaccess-cursorandpointersize' // Build 17040+
 	| 'easeofaccess-cursor'
@@ -690,16 +690,16 @@ export type SystemPreferencesWindowsPane =
 	| 'easeofaccess-mouse'
 	| 'easeofaccess-eyecontrol' // Build 17035+
 	/**
-	 * Search & Cortana
-	 */
+	Search & Cortana
+	*/
 	| 'search-permissions' // Version 1903+
 	| 'cortana-windowssearch' // Version 1903+
 	| 'cortana' // Build 16188+
 	| 'cortana-talktocortana' // Build 16188+
 	| 'cortana-permissions' // Build 16188+
 	/**
-	 * Privacy
-	 */
+	Privacy
+	*/
 	| 'privacy'
 	| 'privacy-speech'
 	| 'privacy-speechtyping'
@@ -729,8 +729,8 @@ export type SystemPreferencesWindowsPane =
 	| 'privacy-videos'
 	| 'privacy-broadfilesystemaccess'
 	/**
-	 * Update & security
-	 */
+	Update & security
+	*/
 	| 'windowsupdate'
 	| 'delivery-optimization'
 	| 'windowsdefender'
@@ -743,7 +743,7 @@ export type SystemPreferencesWindowsPane =
 	| 'windowsinsider';
 
 /**
-Open the System Preferences on macOS.
+Open the System Preferences on macOS and Windows 10.
 
 This method does nothing on other systems.
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -745,9 +745,11 @@ export type SystemPreferencesWindowsPane =
 /**
 Open the System Preferences on macOS and Windows 10.
 
-This method does nothing on other systems.
+This method does nothing on Linux.
 
-Optionally provide a pane and section.
+A list of available options can be found [here](https://github.com/sindresorhus/electron-util/blob/b1deb86cf1cba9a89869b277f8dfbdc7b0ddc888/index.d.ts#L531-L743).
+
+On macOS, optionally provide a pane and section.
 
 @example
 ```

--- a/index.d.ts
+++ b/index.d.ts
@@ -766,4 +766,5 @@ openSystemPreferences('security', 'Firewall');
 @param section - The section within that pane.
 @returns A Promise that resolves when the preferences window is opened.
 */
-export const openSystemPreferences: <T extends keyof SystemPreferencesMacOsPanes>(pane?: T|SystemPreferencesWindowsPane, section?: SystemPreferencesMacOsPanes[T]) => Promise<void>;
+export function openSystemPreferences(pane?: SystemPreferencesWindowsPane): Promise<void>;
+export function openSystemPreferences<T extends keyof SystemPreferencesMacOsPanes>(pane?: T, section?: SystemPreferencesMacOsPanes[T]): Promise<void>;

--- a/index.d.ts
+++ b/index.d.ts
@@ -528,7 +528,7 @@ Menu.setApplicationMenu(menu);
 */
 export function appMenu(menuItems?: readonly MenuItemConstructorOptions[]): MenuItemConstructorOptions;
 
-export interface SystemPreferencesPanes {
+export interface SystemPreferencesMacOsPanes {
 	universalaccess:
 		| 'Captioning'
 		| 'Hearing'
@@ -580,6 +580,168 @@ export interface SystemPreferencesPanes {
 		| 'Services_ScreenSharing';
 }
 
+export type SystemPreferencesWindowsPane =
+	/**
+	 * System
+	 */
+	'display'
+	| 'sound' // Build 17063+
+	| 'notifications'
+	| 'quiethours' // Build 17074+
+	| 'powersleep'
+	| 'batterysaver'
+	| 'storagesense'
+	| 'tabletmode'
+	| 'multitasking'
+	| 'project'
+	| 'crossdevice'
+	| 'clipboard' // Build 17666+
+	| 'remotedesktop'
+	| 'about'
+	/**
+	 * Devices
+	 */
+	| 'bluetooth'
+	| 'connecteddevices'
+	| 'printers'
+	| 'mousetouchpad'
+	| 'devices-touchpad'
+	| 'typing'
+	| 'wheel'
+	| 'pen'
+	| 'autoplay'
+	| 'usb'
+	| 'mobile-devices' // Build 16251+
+	/**
+	 * Network & Internet
+	 */
+	| 'network'
+	| 'network-status'
+	| 'network-cellular'
+	| 'network-wifi'
+	| 'network-wificalling'
+	| 'network-ethernet'
+	| 'network-dialup'
+	| 'network-vpn'
+	| 'network-airplanemode'
+	| 'network-mobilehotspot'
+	| 'nfctransactions'
+	| 'datausage'
+	| 'network-proxy'
+	/**
+	 * Personalization
+	 */
+	| 'personalization'
+	| 'personalization-background'
+	| 'personalization-colors'
+	| 'lockscreen'
+	| 'themes'
+	| 'fonts' // Build 17083+
+	| 'personalization-start'
+	| 'taskbar'
+	/**
+	 * Apps
+	 */
+	| 'appsfeatures'
+	| 'optionalfeatures'
+	| 'defaultapps'
+	| 'maps'
+	| 'appsforwebsites'
+	| 'videoplayback' // Build 16215+
+	| 'startupapps' // Build 17017+
+	/**
+	 * Accounts
+	 */
+	| 'yourinfo'
+	| 'emailandaccounts'
+	| 'signinoptions'
+	| 'workplace'
+	| 'otherusers'
+	| 'sync'
+	/**
+	 * Time & language
+	 */
+	| 'dateandtime'
+	| 'regionformatting'
+	| 'regionlanguage'
+	| 'speech'
+	/**
+	 * Gaming
+	 */
+	| 'gaming-gamebar'
+	| 'gaming-gamedvr'
+	| 'gaming-broadcasting'
+	| 'gaming-gamemode'
+	| 'gaming-xboxnetworking' // Build 16226+
+	/**
+	 * Ease of Access
+	 */
+	| 'easeofaccess-display' // Build 17025+
+	| 'easeofaccess-cursorandpointersize' // Build 17040+
+	| 'easeofaccess-cursor'
+	| 'easeofaccess-magnifier'
+	| 'easeofaccess-colorfilter' // Build 17025+
+	| 'easeofaccess-highcontrast'
+	| 'easeofaccess-narrator'
+	| 'easeofaccess-audio' // Build 17035+
+	| 'easeofaccess-closedcaptioning'
+	| 'easeofaccess-speechrecognition' // Build 17035+
+	| 'easeofaccess-keyboard'
+	| 'easeofaccess-mouse'
+	| 'easeofaccess-eyecontrol' // Build 17035+
+	/**
+	 * Search & Cortana
+	 */
+	| 'search-permissions' // Version 1903+
+	| 'cortana-windowssearch' // Version 1903+
+	| 'cortana' // Build 16188+
+	| 'cortana-talktocortana' // Build 16188+
+	| 'cortana-permissions' // Build 16188+
+	/**
+	 * Privacy
+	 */
+	| 'privacy'
+	| 'privacy-speech'
+	| 'privacy-speechtyping'
+	| 'privacy-feedback'
+	| 'privacy-activityhistory' // Build 17040+
+	| 'privacy-location'
+	| 'privacy-webcam'
+	| 'privacy-microphone'
+	| 'privacy-voiceactivation'
+	| 'privacy-notifications'
+	| 'privacy-accountinfo'
+	| 'privacy-contacts'
+	| 'privacy-calendar'
+	| 'privacy-phonecalls'
+	| 'privacy-callhistory'
+	| 'privacy-email'
+	| 'privacy-eyetracker'
+	| 'privacy-tasks'
+	| 'privacy-messaging'
+	| 'privacy-radios'
+	| 'privacy-customdevices'
+	| 'privacy-backgroundapps'
+	| 'privacy-appdiagnostics'
+	| 'privacy-automaticfiledownloads'
+	| 'privacy-documents'
+	| 'privacy-pictures'
+	| 'privacy-videos'
+	| 'privacy-broadfilesystemaccess'
+	/**
+	 * Update & security
+	 */
+	| 'windowsupdate'
+	| 'delivery-optimization'
+	| 'windowsdefender'
+	| 'backup'
+	| 'troubleshoot'
+	| 'recovery'
+	| 'activation'
+	| 'findmydevice'
+	| 'developers'
+	| 'windowsinsider';
+
 /**
 Open the System Preferences on macOS.
 
@@ -602,4 +764,4 @@ openSystemPreferences('security', 'Firewall');
 @param section - The section within that pane.
 @returns A Promise that resolves when the preferences window is opened.
 */
-export const openSystemPreferences: <T extends keyof SystemPreferencesPanes>(pane?: T, section?: SystemPreferencesPanes[T]) => Promise<void>;
+export const openSystemPreferences: <T extends keyof SystemPreferencesMacOsPanes>(pane?: T|SystemPreferencesWindowsPane, section?: SystemPreferencesMacOsPanes[T]) => Promise<void>;

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -69,4 +69,5 @@ expectType<MenuItemConstructorOptions>(appMenu([
 
 expectType<Promise<void>>(openSystemPreferences());
 expectType<Promise<void>>(openSystemPreferences('security', 'Privacy_Microphone'));
+expectType<Promise<void>>(openSystemPreferences('windowsupdate'));
 expectError(openSystemPreferences('security', 'Bad_Section'));

--- a/readme.md
+++ b/readme.md
@@ -48,7 +48,7 @@ console.log(is.macos && is.main);
 - [`aboutMenuItem()`](#aboutmenuitemoptions-linux-windows)
 - [`debugInfo()`](#debuginfo)
 - [`appMenu()`](#appmenumenuitems-macos)
-- [`openSystemPreferences()`](#opensystempreferences)
+- [`openSystemPreferences()`](#opensystempreferencespane-section-promise-macos-windows)
 
 ### api
 
@@ -496,7 +496,7 @@ Menu.setApplicationMenu(menu);
 
 Type: `Function`
 
-Open the System Preferences on macOS and Windows.
+Open the System Preferences on macOS and Windows 10.
 
 This method does nothing on Linux.
 

--- a/readme.md
+++ b/readme.md
@@ -500,7 +500,9 @@ Open the System Preferences on macOS and Windows 10.
 
 This method does nothing on Linux.
 
-Optionally provide a pane and section<sup>*macOS*</sup>. A list of available options can be found [here](https://github.com/sindresorhus/electron-util/blob/b1deb86cf1cba9a89869b277f8dfbdc7b0ddc888/index.d.ts#L531-L743).
+A list of available options can be found [here](https://github.com/sindresorhus/electron-util/blob/b1deb86cf1cba9a89869b277f8dfbdc7b0ddc888/index.d.ts#L531-L743).
+
+On macOS, optionally provide a pane and section.
 
 #### pane
 

--- a/readme.md
+++ b/readme.md
@@ -48,7 +48,7 @@ console.log(is.macos && is.main);
 - [`aboutMenuItem()`](#aboutmenuitemoptions-linux-windows)
 - [`debugInfo()`](#debuginfo)
 - [`appMenu()`](#appmenumenuitems-macos)
-- [`openSystemPreferences()`](#opensystempreferencespanel-section-promise-macos)
+- [`openSystemPreferences()`](#opensystempreferences)
 
 ### api
 
@@ -492,15 +492,15 @@ const menu = Menu.buildFromTemplate([
 Menu.setApplicationMenu(menu);
 ```
 
-### openSystemPreferences(panel?, section?): Promise<void> <sup>*macOS*</sup>
+### openSystemPreferences(pane?, section?): Promise<void> <sup>*macOS*</sup> <sup>*Windows*</sup>
 
 Type: `Function`
 
-Open the System Preferences on macOS.
+Open the System Preferences on macOS and Windows.
 
-This method does nothing on other systems.
+This method does nothing on Linux.
 
-Optionally provide a pane and section. A list of available options can be found [here](https://github.com/sindresorhus/electron-util/blob/4215b51e741b7ea50a0637abe919e2e7d61b34ac/index.d.ts#L515-L561).
+Optionally provide a pane and section<sup>*macOS*</sup>. A list of available options can be found [here](https://github.com/sindresorhus/electron-util/blob/b1deb86cf1cba9a89869b277f8dfbdc7b0ddc888/index.d.ts#L531-L743).
 
 #### pane
 
@@ -514,7 +514,7 @@ const {openSystemPreferences} = require('electron-util');
 openSystemPreferences('security');
 ```
 
-#### section
+#### section <sup>*macOS*</sup>
 
 Type: `string`
 

--- a/source/open-system-preferences.js
+++ b/source/open-system-preferences.js
@@ -3,9 +3,9 @@ const api = require('./api');
 const is = require('./is');
 
 module.exports = async (pane, section) => {
-	if (!is.macos) {
-		return;
+	if (is.macos) {
+		await api.shell.openExternal(`x-apple.systempreferences:com.apple.preference.${pane}${section ? `?${section}` : ''}`);
+	} else if (is.windows) {
+		await api.shell.openExternal(`ms-settings:${pane}`);
 	}
-
-	await api.shell.openExternal(`x-apple.systempreferences:com.apple.preference.${pane}${section ? `?${section}` : ''}`);
 };


### PR DESCRIPTION
This PR updates `openSystemPreferences(pane?)` api to support Windows 10.

It supports custom Settings panes as first argument (full list on [Microsoft Docs](https://docs.microsoft.com/windows/uwp/launch-resume/launch-settings-app) website).

This is **not** a breaking change and does have backwards compatibility. 
It has been tested on latest Windows 10 and includes updated docs, test & typings.