### PR TITLE
fix: use ./ syntax for exporting a package name export

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,11 +16,11 @@
 			"types": "./distribution/shared/index.d.ts",
 			"default": "./distribution/shared/index.js"
 		},
-		"main": {
+		"./main": {
 			"types": "./distribution/main/index.d.ts",
 			"default": "./distribution/main/index.js"
 		},
-		"node": {
+		"./node": {
 			"types": "./distribution/node/index.d.ts",
 			"default": "./distribution/node/index.js"
 		}


### PR DESCRIPTION
Trying to upgrade from 0.17.2 to 0.18.0 in a project already using esm and electron 28+ but I got errors while importing 

```ts
import { aboutMenuItem } from 'electron-util/main';
```
was reporting `Cannot find module 'electron-util/main' or its corresponding type declarations.` error

adding the `./` prefix is allowing me to have the [documented syntax](https://github.com/sindresorhus/electron-util?tab=readme-ov-file#usage) working

